### PR TITLE
Add Godot Base Classes

### DIFF
--- a/Sandbox/Scripts/Helpers/Node2D.js
+++ b/Sandbox/Scripts/Helpers/Node2D.js
@@ -1,0 +1,38 @@
+import { Vector2 } from "./Vector2.js";
+
+export default class Node2D {
+
+    constructor() {
+        this.globalPosition = new Vector2(0, 0);
+        this.globalRotation = 0;
+        this.globalScale = 1;
+    }
+
+    // Need to update position of children
+    get GlobalPosition() { return this.globalPosition; }
+    set GlobalPosition(value) { this.globalPosition = value; }
+
+    // Need to update rotation of children
+    get GlobalRotation() { return this.globalRotation; }
+    set GlobalRotation(value) { this.globalRotation = value % (2 * Math.PI); }
+
+    // Need to update rotation of children
+    get GlobalScale() { return this.globalScale; }
+    set GlobalScale(value) { this.globalScale = value; }
+
+    /**
+     * 
+     * @param {Vector2} vectorTranslation 
+     */
+    globalTranslate(vectorTranslation) {
+        this.globalPosition.add(vectorTranslation);
+    }
+
+    /**
+     * 
+     * @param {float} rotate Amount of rotation to modify current globalRotate by (Radians)
+     */
+    globalRotate(rotate) {
+        this.globalRotation = (this.globalRotation + rotate) % (2 * Math.PI);
+    }
+}

--- a/Sandbox/Scripts/Helpers/RigidBody2D.js
+++ b/Sandbox/Scripts/Helpers/RigidBody2D.js
@@ -1,0 +1,39 @@
+import { Node2D } from './Node2D.js';
+import { Vector2 } from './Vector2.js';
+
+export default class RigidBody2D extends Node2D {
+    constructor() {
+        super();
+
+        this.appliedForce = new Vector2(0, 0);
+        this.appliedTorque = 0;
+        this.angularVelocity = 0;
+        this.linearVelocity = new Vector2(0, 0);
+        this.mass = 1;
+        this.onBodyEntered = () => {};
+        this.angularDamp = 0;
+        this.linearDamp = 0;
+        this.friction = 0;
+    }
+
+    /**
+     * 
+     * @param {Vector2} offset 
+     * @param {Vector2} force 
+     */
+    addForce(offset, force) {
+
+    }
+
+    performPhysics() {
+
+    }
+
+    physicsProcess() {
+
+    }
+
+    _integrate_forces() {
+        
+    }
+}


### PR DESCRIPTION
Creating draft PR for this branch to keep track of necessary classes to implement. Currently, the branch contains skeleton classes for:
- `Node2D`
- `RigidBody2D`

We need to fully flesh out the requirements of each class, and modify it's desired interface (for example, Rigidbody2D.addForce is a little unclear since both offset and force are vectors).
- `Node2D` -- partially completed
- `RigidBody2D` -- partially completed
- UI components?
- RNG class