### PR TITLE
Hardcode solar system data in ctor & Implement Asteroid Launchers

### DIFF
--- a/Sandbox/Scenes/SolarSystems/Wolf 359 System.json
+++ b/Sandbox/Scenes/SolarSystems/Wolf 359 System.json
@@ -120,7 +120,7 @@
       {      "name":"Asteroid6",
              "position":{"x":223,"y":84}
       },
-      {      "name":"Asteroid",
+      {      "name":"Asteroid7",
              "position":{"x":-45,"y":202}
       }
     ],

--- a/src/solarSystem.js
+++ b/src/solarSystem.js
@@ -15,7 +15,6 @@ export default class SolarSystem{
 		this.warpGates = [];
 		this.planets = [];
 		this.asteroidLaunchers = [];
-		this.solarSystemData = {asteroids: [], asteroidLaunchers: [], warpgates: [], planets: []};
 
         /* INITIALIZATION FORMATTING:
 
@@ -160,22 +159,21 @@ export default class SolarSystem{
 				break;
 			case "Kepler 438 System":
 				// Generate asteroids at modulo offsets (to prevent hardcoding large # of asteroids)
-				//! TODO: UPDATE
-				for (let i = 0; i < 30; i++) {
-					this.asteroids.push(new Asteroid(new Vector2(0, 0), 0, new Vector2(-308, 66), this.game));
+				for (let i = 0; i < 10; i++) {
+					this.asteroids.push(new Asteroid(new Vector2(0, 0), 0, new Vector2((31 + 25 * i) % 71, (17 + 29 * i) % 53), this.game));
 				}
 				this.planets.push(...[
-					new Planet("Planet Kepler 438", {"Common":70, "Metal":20, "Water":10},
-						2, new Vector2(1276, 108), this.game),
-					new Planet("Planet Avallac", {"Common":70, "Metal":20, "Terror":10, "Water":0},
-						2, new Vector2(-1219, -211), this.game)
+					new Planet("planet6", {"Common":70, "Metal":20, "Water":10},
+						2, new Vector2(69, 41), this.game),
+					new Planet("planet4", {"Common":70, "Metal":20, "Terror":10, "Water":0},
+						2, new Vector2(8, 13), this.game)
 				]);
 				this.warpGates.push(...[
-					new WarpGate("Quaid System", new Vector2(-424, 410), this.game),
-					new WarpGate("Sirius System", new Vector2(719, -141), this.game),
-					new WarpGate("Alpha Centauri System", new Vector2(-621, -45), this.game),
-					new WarpGate("Wolf 359 System", new Vector2(-8, -342), this.game),
-					new WarpGate("Groombridge System", new Vector2(245, 558), this.game)
+					new WarpGate("Quaid System", new Vector2(14, 37), this.game),
+					new WarpGate("Sirius System", new Vector2(58, 16), this.game),
+					new WarpGate("Alpha Centauri System", new Vector2(6, 21), this.game),
+					new WarpGate("Wolf 359 System", new Vector2(34, 18), this.game),
+					new WarpGate("Groombridge System", new Vector2(42, 44), this.game)
 				]);
 				break;
 			case "Kruger System": 
@@ -213,20 +211,19 @@ export default class SolarSystem{
 				break;
 			case "Quaid System":
 				// Generate asteroids at modulo offsets (to prevent hardcoding large # of asteroids)
-				//! TODO: UPDATE
-				for (let i = 0; i < 30; i++) {
-					this.asteroids.push(new Asteroid(new Vector2(0, 0), 0, new Vector2(-308, 66), this.game));
+				for (let i = 0; i < 5; i++) {
+					this.asteroids.push(new Asteroid(new Vector2(0, 0), 0, new Vector2((51 + 41 * i) % 71, (41 + 41 * i) % 53), this.game));
 				}
 				this.asteroidLaunchers.push(...[
-					new AsteroidLauncher(new Vector2(-704, -725), this.game),
-					new AsteroidLauncher(new Vector2(-243, 529), this.game)
+					new AsteroidLauncher(new Vector2(8, 5), this.game, 4, 15),
+					new AsteroidLauncher(new Vector2(26, 41), this.game, 7, 10)
 				]);
 				this.warpGates.push(...[
-					new WarpGate("Yennefer System", new Vector2(640, -147), this.game),
-					new WarpGate("Indi System", new Vector2(285, 440), this.game),
-					new WarpGate("Kepler 438 System", new Vector2(905, -33), this.game),
-					new WarpGate("Cygni System", new Vector2(-316, 115), this.game),
-					new WarpGate("Groombridge System", new Vector2(7, -244), this.game)
+					new WarpGate("Yennefer System", new Vector2(59, 19), this.game),
+					new WarpGate("Indi System", new Vector2(41, 41), this.game),
+					new WarpGate("Kepler 438 System", new Vector2(70, 24), this.game),
+					new WarpGate("Cygni System", new Vector2(11, 28), this.game),
+					new WarpGate("Groombridge System", new Vector2(30, 16), this.game)
 				]);
 				break;
 			case "Sirius System":

--- a/src/solarSystem.js
+++ b/src/solarSystem.js
@@ -22,7 +22,7 @@ export default class SolarSystem{
         -----     Asteroid     -----
         new Asteroid([speed.x, speed.y], aspeed, [pos.x, pos.y], this.game);
 		----- AsteroidLauncher -----
-		new AsteroidLauncher([pos.x, pos.y], this.game);
+		new AsteroidLauncher([pos.x, pos.y], this.game, spawnPeriod = 4, spawnCount = 10, rotation = -1);
         -----      Planet      -----
         new Planet("imageName", [pos.x, pos.y], this.game);
 		-----     Warp Gate    -----
@@ -55,106 +55,107 @@ export default class SolarSystem{
                     new Planet("planet13", 2, {}, new Vector2(68, 11), this.game),
                     new Planet("planet14", 2, {}, new Vector2(63, 48), this.game),
                 ]);
+
+				this.asteroidLaunchers.push(new AsteroidLauncher(new Vector2(50, 50), this.game, 4, 10, Math.PI * 3 / 4));
 				break;
 			case "Alpha Centauri System":
 				this.asteroids.push(...[
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(-261, 343), this.game),
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(-393, -272), this.game),
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(458, -272), this.game),
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(607, 233), this.game),
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(153, 166), this.game),
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(117, -222), this.game),
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(-548, 194), this.game)
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(20, 42), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(13, 17), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(43, 11), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(68, 38), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(46, 31), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(4, 28), this.game)
 				]);
 				this.warpGates.push(...[
-					new WarpGate("Sol System", new Vector2(-643, -269), this.game),
-					new WarpGate("Bernard's Star System", new Vector2(-313, 468), this.game),
-					new WarpGate("Kruger System", new Vector2(676, 525), this.game),
-					new WarpGate("Wolf 359 System", new Vector2(730, -268), this.game),
-					new WarpGate("Kepler 438 System", new Vector2(313, 386), this.game)
+					new WarpGate("Sol System", new Vector2(3, 8), this.game),
+					new WarpGate("Bernard's Star System", new Vector2(11, 41), this.game),
+					new WarpGate("Kruger System", new Vector2(51, 49), this.game),
+					new WarpGate("Wolf 359 System", new Vector2(53, 6), this.game),
+					new WarpGate("Kepler 438 System", new Vector2(32, 39), this.game)
 				]);
 				break;
 			case "Aquarii System": 
 				this.asteroids.push(...[
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(-369, -227), this.game),
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(-351, -123), this.game),
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(-390, -15), this.game),
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(-472, 76), this.game),
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(-585, 130), this.game),
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(646, -67), this.game),
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(531, -32), this.game),
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(441, -43), this.game),
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(378, 153), this.game),
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(352, 283), this.game)
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(23, 9), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(21, 13), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(16, 44), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(11, 28), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(3, 32), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(49, 23), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(70, 4), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(63, 24), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(52, 36), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(54, 49), this.game)
 				]);
 				this.warpGates.push(...[
-					new WarpGate("Groombridge System", new Vector2(-639, -91), this.game),
-					new WarpGate("Wolf 359 System", new Vector2(576, 199), this.game)
+					new WarpGate("Groombridge System", new Vector2(3, 16), this.game),
+					new WarpGate("Wolf 359 System", new Vector2(60, 21), this.game)
 				]);
 				break;
 			case "Barnard's Star System":
 				this.asteroids.push(...[
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(-321, -172), this.game),
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(-309, -256), this.game),
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(644, -109), this.game),
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(574, 228), this.game),
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(-39, 415), this.game),
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(-103, 277), this.game),
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(324, 192), this.game),
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(412, -38), this.game),
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(-155, -284), this.game)
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(4, 10), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(6, 4), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(70, 16), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(61, 37), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(37, 45), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(23, 34), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(48, 26), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(51, 19), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(17, 14), this.game)
 				]);
 				this.warpGates.push(...[
-					new WarpGate("Alpha Centauri System", new Vector2(-418, -320), this.game),
-					new WarpGate("Sol System", new Vector2(-66, 547), this.game),
-					new WarpGate("Sirius System", new Vector2(763, -142), this.game),
-					new WarpGate("Wolf 359 System", new Vector2(693, 256), this.game),
-					new WarpGate("Indi System", new Vector2(-440, 246), this.game)
+					new WarpGate("Alpha Centauri System", new Vector2(8, 8), this.game),
+					new WarpGate("Sol System", new Vector2(36, 52), this.game),
+					new WarpGate("Sirius System", new Vector2(71, 11), this.game),
+					new WarpGate("Wolf 359 System", new Vector2(68, 41), this.game),
+					new WarpGate("Indi System", new Vector2(9, 48), this.game)
 				]);
 				break;
 			case "Cygni System":
 				this.asteroids.push(...[
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(576, 235), this.game),
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(484, 109), this.game),
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(387, -21), this.game),
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(248, -151), this.game),
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(118, -231), this.game)
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(67, 40), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(61, 31), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(31, 4), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(25, 18), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(11, 7), this.game)
 				]);
 				this.asteroidLaunchers.push(...[
-					new AsteroidLauncher(new Vector2(997, 1152), this.game),
-					new AsteroidLauncher(new Vector2(-198, -1068), this.game)
+					new AsteroidLauncher(new Vector2(61, 51), this.game, 5, 10),
+					new AsteroidLauncher(new Vector2(21, 2), this.game, 4, 12, Math.PI/4)
 				]);
 				this.warpGates.push(...[
-					new WarpGate("Alpha Centauri System", new Vector2(-266, 377), this.game),
-					new WarpGate("Sol System", new Vector2(870, -246), this.game)
+					new WarpGate("Alpha Centauri System", new Vector2(13, 27), this.game),
+					new WarpGate("Sol System", new Vector2(58, 11), this.game)
 				]);
 				break;
 			case "Groombridge System":
 				this.warpGates.push(...[
-					new WarpGate("Quaid System", new Vector2(485, -397), this.game),
-					new WarpGate("Kepler 438 System", new Vector2(892, 381), this.game),
-					new WarpGate("Wolf 359 System", new Vector2(-431, -217), this.game),
-					new WarpGate("Aquarii System", new Vector2(-306, 302), this.game)
+					new WarpGate("Quaid System", new Vector2(51, 11), this.game),
+					new WarpGate("Kepler 438 System", new Vector2(70, 47), this.game),
+					new WarpGate("Wolf 359 System", new Vector2(9, 21), this.game),
+					new WarpGate("Aquarii System", new Vector2(14, 42), this.game)
 				]);
 				break;
 			case "Indi System":
 				this.asteroids.push(...[
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(-207, 86), this.game),
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(-91, 196), this.game),
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(220, 276), this.game),
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(490, 91), this.game),
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(389, -240), this.game),
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(190, -257), this.game),
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(753, -140), this.game),
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(702, 194), this.game),
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(123, 417), this.game),
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(-186, 512), this.game),
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(-218, -233), this.game)
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(10, 28), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(29, 35), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(41, 34), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(51, 27), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(48, 15), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(37, 14), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(70, 19), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(68, 26), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(38, 43), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(30, 50), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(6, 5), this.game)
 				]);
 				this.warpGates.push(...[
-					new WarpGate("Quaid System", new Vector2(668, -292), this.game),
-					new WarpGate("Luyten System", new Vector2(-382, 358), this.game),
-					new WarpGate("Barnard's Star System", new Vector2(648, 391), this.game)
+					new WarpGate("Quaid System", new Vector2(68, 3), this.game),
+					new WarpGate("Luyten System", new Vector2(2, 41), this.game),
+					new WarpGate("Barnard's Star System", new Vector2(66, 41), this.game)
 				]);
 				break;
 			case "Kepler 438 System":
@@ -179,35 +180,35 @@ export default class SolarSystem{
 				break;
 			case "Kruger System": 
 				this.asteroids.push(...[
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(-503, -107), this.game),
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(-392, -195), this.game),
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(-320, -380), this.game),
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(-501, -429), this.game),
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(-656, -364), this.game),
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(636, -204), this.game),
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(47, -200), this.game),
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(-200, 188), this.game),
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(-293, 265), this.game)
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(9, 26), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(21, 24), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(25, 13), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(6, 5), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(2, 11), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(68, 21), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(36, 20), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(31, 23), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(29, 49), this.game)
 				]);
-				this.warpGates.push(new WarpGate("Alpha Centauri System", new Vector2(-505, -286), this.game));
+				this.warpGates.push(new WarpGate("Alpha Centauri System", new Vector2(4, 14), this.game));
 				break;
 			case "Luyten System":
 				this.asteroids.push(...[
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(-308, 66), this.game),
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(-138, 300), this.game),
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(-341, 497), this.game),
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(275, 76), this.game),
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(185, -185), this.game),
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(-94, -175), this.game),
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(-121, -434), this.game),
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(247, 209), this.game),
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(543, -191), this.game)
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(18, 25), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(34, 38), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(14, 49), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(41, 27), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(36, 22), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(32, 23), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(30, 4), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(45, 31), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(65, 20), this.game)
 				]);
-				this.asteroidLaunchers.push(new AsteroidLauncher(new Vector2(-532, -499), this.game));
+				this.asteroidLaunchers.push(new AsteroidLauncher(new Vector2(4, 3), this.game, 4, 20, Math.PI / 6));
 				this.warpGates.push(...[
-					new WarpGate("Cygni System", new Vector2(3, -329), this.game),
-					new WarpGate("Sirius System", new Vector2(-396, 303), this.game),
-					new WarpGate("Indi System", new Vector2(401, 329), this.game)
+					new WarpGate("Cygni System", new Vector2(37, 9), this.game),
+					new WarpGate("Sirius System", new Vector2(11, 40), this.game),
+					new WarpGate("Indi System", new Vector2(61, 39), this.game)
 				]);
 				break;
 			case "Quaid System":
@@ -230,77 +231,58 @@ export default class SolarSystem{
 				break;
 			case "Sirius System":
 				this.asteroids.push(...[
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(222, -117), this.game),
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(142, 177), this.game),
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(434, 339), this.game),
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(701, 216), this.game),
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(655, -189), this.game)
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(41, 24), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(35, 12), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(47, 42), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(70, 34), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(64, 23), this.game)
 				]);
 				this.warpGates.push(...[
-					new WarpGate("Luyten System", new Vector2(-297, 155), this.game),
-					new WarpGate("Barnard's Star System", new Vector2(179, -152), this.game),
-					new WarpGate("Kepler 438 System", new Vector2(513, -453), this.game),
-					new WarpGate("Sol System", new Vector2(-506, -33), this.game)
+					new WarpGate("Luyten System", new Vector2(21, 43), this.game),
+					new WarpGate("Barnard's Star System", new Vector2(37, 25), this.game),
+					new WarpGate("Kepler 438 System", new Vector2(59, 4), this.game),
+					new WarpGate("Sol System", new Vector2(3, 29), this.game)
 				]);
 				break;
 			case "Sol System":
 				this.asteroids.push(...[
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(600, 0), this.game),
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(1011, -469), this.game),
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(729, 429), this.game),
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(830, -493), this.game),
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(539, -484), this.game),
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(800, -200), this.game),
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(800, 200), this.game)
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(21, 20), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(70, 4), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(37, 48), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(51, 5), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(11, 7), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(46, 13), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(46, 31), this.game)
 				]);
 				this.warpGates.push(...[
-					new WarpGate("Alpha Centauri System", new Vector2(800, 0), this.game),
-					new WarpGate("Barnard's Star System", new Vector2(746, 599), this.game),
-					new WarpGate("Sirius System", new Vector2(1107, -369), this.game)
+					new WarpGate("Alpha Centauri System", new Vector2(43, 23), this.game),
+					new WarpGate("Barnard's Star System", new Vector2(35, 52), this.game),
+					new WarpGate("Sirius System", new Vector2(69, 14), this.game)
 				]);
 				break;
 			case "Wolf 359 System": 
 				this.asteroids.push(...[
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(-479, -7), this.game),
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(-334, 318), this.game),
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(320, 361), this.game),
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(454, -70), this.game),
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(0, -298), this.game),
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(223, 84), this.game),
-					new Asteroid(new Vector2(0, 0), 0, new Vector2(-45, 202), this.game)
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(15, -7), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(24, 42), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(43, 45), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(51, 24), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(34, 15), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(39, 22), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(28, 27), this.game)
 				]);
 				this.warpGates.push(...[
-					new WarpGate("Aquarii System", new Vector2(-498, -345), this.game),
-					new WarpGate("Groombridge System", new Vector2(800, -266), this.game),
-					new WarpGate("Kepler 438 System", new Vector2(-718, 359), this.game),
-					new WarpGate("Alpha Centauri System", new Vector2(145, 573), this.game),
-					new WarpGate("Barnard's Star System", new Vector2(759, 218), this.game)
+					new WarpGate("Aquarii System", new Vector2(18, 8), this.game),
+					new WarpGate("Groombridge System", new Vector2(67, 10), this.game),
+					new WarpGate("Kepler 438 System", new Vector2(4, 36), this.game),
+					new WarpGate("Alpha Centauri System", new Vector2(38, 50), this.game),
+					new WarpGate("Barnard's Star System", new Vector2(64, 30), this.game)
 				]);
 				break;
 			case "Yennefer System":
-				this.warpGates.push(new WarpGate("Quaid System", new Vector2(575, -116), this.game));
+				this.warpGates.push(new WarpGate("Quaid System", new Vector2(48, 16), this.game));
 				break;
 		}
 
-		// // Add asteroids to solar system
-		// for (const asteroid of this.solarSystemData.asteroids) {
-		// 	this.asteroids.push(new Asteroid(new Vector2(0,0), 0, new Vector2(asteroid.position.x, asteroid.position.y), this.game));
-		// }
-
-		// // Add planets to solar system (containing name, scan signature, gravity signature, etc)
-		// for (const planet of this.solarSystemData.planets) {
-		// 	this.planets.push(new Planet(planet.name, planet.scanSignature, planet.gravitySignature, new Vector2(planet.position.x, planet.position.y), this.game));
-		// }
-
-		// // Add asteroid launchers (containing position)
-		// for (const asteroidLaunchers of this.solarSystemData.asteroidLaunchers) {
-		// 	this.asteroidLaunchers.push(new AsteroidLauncher(asteroidLaunchers.position, this.game));
-		// }
-
-		// // Add warpgates (containing destination solar system name, position)
-		// for (const warpgate of this.solarSystemData.warpgates) {
-		// 	this.warpGates.push(new WarpGate(warpgate.to, warpgate.position, this.game));
-		// }
 	}
 	addWarpGate(){
 		//Link togethers solarsystems with warpgates

--- a/src/solarSystem.js
+++ b/src/solarSystem.js
@@ -21,7 +21,7 @@ export default class SolarSystem{
         -----     Asteroid     -----
         new Asteroid([speed.x, speed.y], aspeed, [pos.x, pos.y], this.game);
 		----- AsteroidLauncher -----
-		new AsteroidLauncher([pos.x, pos.y], this.game, spawnPeriod = 4, spawnCount = 10, rotation = -1);
+		new AsteroidLauncher([pos.x, pos.y], this.game, spawnPeriod = 4, spawnCount = -1, rotation = -1);
         -----      Planet      -----
         new Planet("imageName", [pos.x, pos.y], this.game);
 		-----     Warp Gate    -----

--- a/src/solarSystem.js
+++ b/src/solarSystem.js
@@ -4,14 +4,6 @@ import WarpGate from "./spaceObjects/warpGate.js";
 import Planet from "./spaceObjects/planet.js";
 import AsteroidLauncher from "./spaceObjects/asteroidLauncher.js";
 
-// import AlphaCentauri from "../Sandbox/Scenes/SolarSystems/Alpha Centauri System.json" assert { type: "json" };
-// import Sol from "../Sandbox/Scenes/SolarSystems/Sol System.json" assert { type: "json" };
-// import Kepler438 from "../Sandbox/Scenes/SolarSystems/Kepler 438 System.json" assert { type: "json" };
-// import Aquarii from "../Sandbox/Scenes/SolarSystems/Aquarii System.json" assert { type: "json" };
-// import Barnards from "../Sandbox/Scenes/SolarSystems/Barnard's Star System.json" assert { type: "json" };
-// import Kruger from "../Sandbox/Scenes/SolarSystems/Kruger System.json" assert { type: "json" };
-// import Wolf359 from "../Sandbox/Scenes/SolarSystems/Wolf 359 System.json" assert { type: "json" };
-
 //Parent class for solarsystems, use data from solarsystem jsons and galaxy and spaceobjects scripts
 //The constructor is going to build the levels
 //Think of this as sort of a level builder
@@ -27,10 +19,14 @@ export default class SolarSystem{
 
         /* INITIALIZATION FORMATTING:
 
-        ----- Asteroid -----
-        newAsteroid([speed.x, speed.y], aspeed, [pos.x, pos.y], this.game);
-        -----  Planet  -----
+        -----     Asteroid     -----
+        new Asteroid([speed.x, speed.y], aspeed, [pos.x, pos.y], this.game);
+		----- AsteroidLauncher -----
+		new AsteroidLauncher([pos.x, pos.y], this.game);
+        -----      Planet      -----
         new Planet("imageName", [pos.x, pos.y], this.game);
+		-----     Warp Gate    -----
+		new WarpGate("destination", [pos.x, pos.y], this.game);
 
         */
 		switch(this.name){
@@ -61,47 +57,250 @@ export default class SolarSystem{
                 ]);
 				break;
 			case "Alpha Centauri System":
-				// this.solarSystemData = AlphaCentauri;
-				break;
-			case "Sol System":
-				// this.solarSystemData = Sol;
-				break;
-			case "Kepler 438 System":
-				// this.solarSystemData = Kepler438;
+				this.asteroids.push(...[
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(-261, 343), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(-393, -272), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(458, -272), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(607, 233), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(153, 166), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(117, -222), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(-548, 194), this.game)
+				]);
+				this.warpGates.push(...[
+					new WarpGate("Sol System", new Vector2(-643, -269), this.game),
+					new WarpGate("Bernard's Star System", new Vector2(-313, 468), this.game),
+					new WarpGate("Kruger System", new Vector2(676, 525), this.game),
+					new WarpGate("Wolf 359 System", new Vector2(730, -268), this.game),
+					new WarpGate("Kepler 438 System", new Vector2(313, 386), this.game)
+				]);
 				break;
 			case "Aquarii System": 
-				// this.solarSystemData = Aquarii;
+				this.asteroids.push(...[
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(-369, -227), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(-351, -123), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(-390, -15), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(-472, 76), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(-585, 130), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(646, -67), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(531, -32), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(441, -43), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(378, 153), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(352, 283), this.game)
+				]);
+				this.warpGates.push(...[
+					new WarpGate("Groombridge System", new Vector2(-639, -91), this.game),
+					new WarpGate("Wolf 359 System", new Vector2(576, 199), this.game)
+				]);
 				break;
 			case "Barnard's Star System":
-				// this.solarSystemData = Barnards;
+				this.asteroids.push(...[
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(-321, -172), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(-309, -256), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(644, -109), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(574, 228), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(-39, 415), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(-103, 277), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(324, 192), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(412, -38), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(-155, -284), this.game)
+				]);
+				this.warpGates.push(...[
+					new WarpGate("Alpha Centauri System", new Vector2(-418, -320), this.game),
+					new WarpGate("Sol System", new Vector2(-66, 547), this.game),
+					new WarpGate("Sirius System", new Vector2(763, -142), this.game),
+					new WarpGate("Wolf 359 System", new Vector2(693, 256), this.game),
+					new WarpGate("Indi System", new Vector2(-440, 246), this.game)
+				]);
+				break;
+			case "Cygni System":
+				this.asteroids.push(...[
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(576, 235), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(484, 109), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(387, -21), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(248, -151), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(118, -231), this.game)
+				]);
+				this.asteroidLaunchers.push(...[
+					new AsteroidLauncher(new Vector2(997, 1152), this.game),
+					new AsteroidLauncher(new Vector2(-198, -1068), this.game)
+				]);
+				this.warpGates.push(...[
+					new WarpGate("Alpha Centauri System", new Vector2(-266, 377), this.game),
+					new WarpGate("Sol System", new Vector2(870, -246), this.game)
+				]);
+				break;
+			case "Groombridge System":
+				this.warpGates.push(...[
+					new WarpGate("Quaid System", new Vector2(485, -397), this.game),
+					new WarpGate("Kepler 438 System", new Vector2(892, 381), this.game),
+					new WarpGate("Wolf 359 System", new Vector2(-431, -217), this.game),
+					new WarpGate("Aquarii System", new Vector2(-306, 302), this.game)
+				]);
+				break;
+			case "Indi System":
+				this.asteroids.push(...[
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(-207, 86), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(-91, 196), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(220, 276), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(490, 91), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(389, -240), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(190, -257), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(753, -140), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(702, 194), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(123, 417), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(-186, 512), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(-218, -233), this.game)
+				]);
+				this.warpGates.push(...[
+					new WarpGate("Quaid System", new Vector2(668, -292), this.game),
+					new WarpGate("Luyten System", new Vector2(-382, 358), this.game),
+					new WarpGate("Barnard's Star System", new Vector2(648, 391), this.game)
+				]);
+				break;
+			case "Kepler 438 System":
+				// Generate asteroids at modulo offsets (to prevent hardcoding large # of asteroids)
+				//! TODO: UPDATE
+				for (let i = 0; i < 30; i++) {
+					this.asteroids.push(new Asteroid(new Vector2(0, 0), 0, new Vector2(-308, 66), this.game));
+				}
+				this.planets.push(...[
+					new Planet("Planet Kepler 438", {"Common":70, "Metal":20, "Water":10},
+						2, new Vector2(1276, 108), this.game),
+					new Planet("Planet Avallac", {"Common":70, "Metal":20, "Terror":10, "Water":0},
+						2, new Vector2(-1219, -211), this.game)
+				]);
+				this.warpGates.push(...[
+					new WarpGate("Quaid System", new Vector2(-424, 410), this.game),
+					new WarpGate("Sirius System", new Vector2(719, -141), this.game),
+					new WarpGate("Alpha Centauri System", new Vector2(-621, -45), this.game),
+					new WarpGate("Wolf 359 System", new Vector2(-8, -342), this.game),
+					new WarpGate("Groombridge System", new Vector2(245, 558), this.game)
+				]);
 				break;
 			case "Kruger System": 
-				// this.solarSystemData = Kruger;
+				this.asteroids.push(...[
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(-503, -107), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(-392, -195), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(-320, -380), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(-501, -429), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(-656, -364), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(636, -204), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(47, -200), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(-200, 188), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(-293, 265), this.game)
+				]);
+				this.warpGates.push(new WarpGate("Alpha Centauri System", new Vector2(-505, -286), this.game));
+				break;
+			case "Luyten System":
+				this.asteroids.push(...[
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(-308, 66), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(-138, 300), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(-341, 497), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(275, 76), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(185, -185), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(-94, -175), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(-121, -434), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(247, 209), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(543, -191), this.game)
+				]);
+				this.asteroidLaunchers.push(new AsteroidLauncher(new Vector2(-532, -499), this.game));
+				this.warpGates.push(...[
+					new WarpGate("Cygni System", new Vector2(3, -329), this.game),
+					new WarpGate("Sirius System", new Vector2(-396, 303), this.game),
+					new WarpGate("Indi System", new Vector2(401, 329), this.game)
+				]);
+				break;
+			case "Quaid System":
+				// Generate asteroids at modulo offsets (to prevent hardcoding large # of asteroids)
+				//! TODO: UPDATE
+				for (let i = 0; i < 30; i++) {
+					this.asteroids.push(new Asteroid(new Vector2(0, 0), 0, new Vector2(-308, 66), this.game));
+				}
+				this.asteroidLaunchers.push(...[
+					new AsteroidLauncher(new Vector2(-704, -725), this.game),
+					new AsteroidLauncher(new Vector2(-243, 529), this.game)
+				]);
+				this.warpGates.push(...[
+					new WarpGate("Yennefer System", new Vector2(640, -147), this.game),
+					new WarpGate("Indi System", new Vector2(285, 440), this.game),
+					new WarpGate("Kepler 438 System", new Vector2(905, -33), this.game),
+					new WarpGate("Cygni System", new Vector2(-316, 115), this.game),
+					new WarpGate("Groombridge System", new Vector2(7, -244), this.game)
+				]);
+				break;
+			case "Sirius System":
+				this.asteroids.push(...[
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(222, -117), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(142, 177), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(434, 339), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(701, 216), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(655, -189), this.game)
+				]);
+				this.warpGates.push(...[
+					new WarpGate("Luyten System", new Vector2(-297, 155), this.game),
+					new WarpGate("Barnard's Star System", new Vector2(179, -152), this.game),
+					new WarpGate("Kepler 438 System", new Vector2(513, -453), this.game),
+					new WarpGate("Sol System", new Vector2(-506, -33), this.game)
+				]);
+				break;
+			case "Sol System":
+				this.asteroids.push(...[
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(600, 0), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(1011, -469), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(729, 429), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(830, -493), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(539, -484), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(800, -200), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(800, 200), this.game)
+				]);
+				this.warpGates.push(...[
+					new WarpGate("Alpha Centauri System", new Vector2(800, 0), this.game),
+					new WarpGate("Barnard's Star System", new Vector2(746, 599), this.game),
+					new WarpGate("Sirius System", new Vector2(1107, -369), this.game)
+				]);
 				break;
 			case "Wolf 359 System": 
-				// this.solarSystemData = Wolf359;
+				this.asteroids.push(...[
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(-479, -7), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(-334, 318), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(320, 361), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(454, -70), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(0, -298), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(223, 84), this.game),
+					new Asteroid(new Vector2(0, 0), 0, new Vector2(-45, 202), this.game)
+				]);
+				this.warpGates.push(...[
+					new WarpGate("Aquarii System", new Vector2(-498, -345), this.game),
+					new WarpGate("Groombridge System", new Vector2(800, -266), this.game),
+					new WarpGate("Kepler 438 System", new Vector2(-718, 359), this.game),
+					new WarpGate("Alpha Centauri System", new Vector2(145, 573), this.game),
+					new WarpGate("Barnard's Star System", new Vector2(759, 218), this.game)
+				]);
+				break;
+			case "Yennefer System":
+				this.warpGates.push(new WarpGate("Quaid System", new Vector2(575, -116), this.game));
 				break;
 		}
 
-		// Add asteroids to solar system
-		for (const asteroid of this.solarSystemData.asteroids) {
-			this.asteroids.push(new Asteroid(new Vector2(0,0), 0, new Vector2(asteroid.position.x, asteroid.position.y), this.game));
-		}
+		// // Add asteroids to solar system
+		// for (const asteroid of this.solarSystemData.asteroids) {
+		// 	this.asteroids.push(new Asteroid(new Vector2(0,0), 0, new Vector2(asteroid.position.x, asteroid.position.y), this.game));
+		// }
 
-		// Add planets to solar system (containing name, scan signature, gravity signature, etc)
-		for (const planet of this.solarSystemData.planets) {
-			this.planets.push(new Planet(planet.name, planet.scanSignature, planet.gravitySignature, new Vector2(planet.position.x, planet.position.y), this.game));
-		}
+		// // Add planets to solar system (containing name, scan signature, gravity signature, etc)
+		// for (const planet of this.solarSystemData.planets) {
+		// 	this.planets.push(new Planet(planet.name, planet.scanSignature, planet.gravitySignature, new Vector2(planet.position.x, planet.position.y), this.game));
+		// }
 
-		// Add asteroid launchers (containing position)
-		for (const asteroidLaunchers of this.solarSystemData.asteroidLaunchers) {
-			this.asteroidLaunchers.push(new AsteroidLauncher(asteroidLaunchers.position, this.game));
-		}
+		// // Add asteroid launchers (containing position)
+		// for (const asteroidLaunchers of this.solarSystemData.asteroidLaunchers) {
+		// 	this.asteroidLaunchers.push(new AsteroidLauncher(asteroidLaunchers.position, this.game));
+		// }
 
-		// Add warpgates (containing destination solar system name, position)
-		for (const warpgate of this.solarSystemData.warpgates) {
-			this.warpGates.push(new WarpGate(warpgate.to, warpgate.position, this.game));
-		}
+		// // Add warpgates (containing destination solar system name, position)
+		// for (const warpgate of this.solarSystemData.warpgates) {
+		// 	this.warpGates.push(new WarpGate(warpgate.to, warpgate.position, this.game));
+		// }
 	}
 	addWarpGate(){
 		//Link togethers solarsystems with warpgates

--- a/src/solarSystem.js
+++ b/src/solarSystem.js
@@ -23,7 +23,7 @@ export default class SolarSystem{
 		----- AsteroidLauncher -----
 		new AsteroidLauncher([pos.x, pos.y], this.game, spawnPeriod = 4, spawnCount = -1, rotation = -1);
         -----      Planet      -----
-        new Planet("imageName", [pos.x, pos.y], this.game);
+        new Planet("imageName", composition, gravitySignature, [pos.x, pos.y], this.game);
 		-----     Warp Gate    -----
 		new WarpGate("destination", [pos.x, pos.y], this.game);
 
@@ -39,20 +39,20 @@ export default class SolarSystem{
                     new Asteroid(new Vector2(0, 0), 0.12, new Vector2(54, 20), this.game)
                 ]);
 				this.planets.push(...[
-                    new Planet("planet1", 2, {}, new Vector2(50, 10), this.game),
-                    new Planet("planet2", 2, {}, new Vector2(10, 50), this.game),
-                    new Planet("planet3", 2, {}, new Vector2(60, 35), this.game),
-                    new Planet("planet4", 2, {}, new Vector2(24, 19), this.game),
-                    new Planet("planet5", 2, {}, new Vector2(33, 44), this.game),
-                    new Planet("planet6", 2, {}, new Vector2(4, 9), this.game),
-                    new Planet("planet7", 2, {}, new Vector2(11, 6), this.game),
-                    new Planet("planet8", 2, {}, new Vector2(14, 23), this.game),
-                    new Planet("planet9", 2, {}, new Vector2(19, 21), this.game),
-                    new Planet("planet10", 2, {}, new Vector2(26, 46), this.game),
-                    new Planet("planet11", 2, {}, new Vector2(37, 27), this.game),
-                    new Planet("planet12", 2, {}, new Vector2(34, 40), this.game),
-                    new Planet("planet13", 2, {}, new Vector2(68, 11), this.game),
-                    new Planet("planet14", 2, {}, new Vector2(63, 48), this.game),
+                    new Planet("planet1", {}, 2, new Vector2(50, 10), this.game),
+                    new Planet("planet2", {}, 2, new Vector2(10, 50), this.game),
+                    new Planet("planet3", {}, 2, new Vector2(60, 35), this.game),
+                    new Planet("planet4", {}, 2, new Vector2(24, 19), this.game),
+                    new Planet("planet5", {}, 2, new Vector2(33, 44), this.game),
+                    new Planet("planet6", {}, 2, new Vector2(4, 9), this.game),
+                    new Planet("planet7", {}, 2, new Vector2(11, 6), this.game),
+                    new Planet("planet8", {}, 2, new Vector2(14, 23), this.game),
+                    new Planet("planet9", {}, 2, new Vector2(19, 21), this.game),
+                    new Planet("planet10", {}, 2, new Vector2(26, 46), this.game),
+                    new Planet("planet11", {}, 2, new Vector2(37, 27), this.game),
+                    new Planet("planet12", {}, 2, new Vector2(34, 40), this.game),
+                    new Planet("planet13", {}, 2, new Vector2(68, 11), this.game),
+                    new Planet("planet14", {}, 2, new Vector2(63, 48), this.game),
                 ]);
 
 				this.asteroidLaunchers.push(new AsteroidLauncher(new Vector2(50, 50), this.game, 4, 10, Math.PI * 3 / 4));

--- a/src/spaceObjects/asteroidLauncher.js
+++ b/src/spaceObjects/asteroidLauncher.js
@@ -2,16 +2,53 @@ import Asteroid from "./asteroid.js";
 import Vector2 from "../helpers/Vector2.js";
 
 const MAX_SPAWN_SPEED = 0.4;
+const FRAMES_PER_SECOND = 60;
 
 export default class AsteroidLauncher{
-	constructor(pos, game) {
+	constructor(pos, game, spawnPeriod = 4, spawnCount = -1, rotation = -1) {
 		this.game = game;
 		this.pos = pos;
+		console.log(rotation);
+
+		this.currentDelay = 0;
+		this.spawnPeriod = spawnPeriod * FRAMES_PER_SECOND;
+
+		// Expects positive integer... -1 denotes infinite projectiles
+		this.spawnCount = spawnCount;
+
+		// Expects positive radians values... rotation == -1 denotes random angle
+		this.rotation = rotation;
 	}
+
+	/**
+	 * Functions gets the rotation angle for the launcher. Rotation can either be fixed or randomized depending on ctor input
+	 * @returns Positive float denoting rotation angle in radians
+	 */
+	getAngle() {
+		return this.rotation != -1 ? this.rotation : Math.random()*2*Math.PI;
+	}
+
 	launchAsteroid(){
+		// Check if additional objects should be created (decrement spawnCount if there are finite asteroids to create)
+		if (this.spawnCount == 0) return;
+		else if (this.spawnCount != -1) this.spawnCount--;
+
 		const speed = Math.random()*MAX_SPAWN_SPEED;									// random speed		
-		const velocity = Vector2.right.rotate(Math.random()*2*Math.PI).scale(speed); 	// random direction
-		let asteroid = new Asteroid(velocity, Math.random()-0.5, this.pos, this.game);	
+		const angle = this.getAngle();
+		const velocity = Vector2.right.rotate(angle).scale(speed); 	// random direction
+		console.log(angle);
+		let asteroid = new Asteroid(velocity, Math.random()-0.5, this.pos, this.game);
 		this.game.spawnDeletableObject(asteroid);
+	}
+
+	update() {
+		if (this.spawnCount === 0) return;
+		if (this.currentDelay === this.spawnPeriod) {
+			console.log("Spawned new asteroid");
+			this.launchAsteroid();
+			this.currentDelay = 0;
+		} else {
+			this.currentDelay++;
+		}
 	}
 }	

--- a/src/spaceObjects/asteroidLauncher.js
+++ b/src/spaceObjects/asteroidLauncher.js
@@ -8,7 +8,6 @@ export default class AsteroidLauncher{
 	constructor(pos, game, spawnPeriod = 4, spawnCount = -1, rotation = -1) {
 		this.game = game;
 		this.pos = pos;
-		console.log(rotation);
 
 		this.currentDelay = 0;
 		this.spawnPeriod = spawnPeriod * FRAMES_PER_SECOND;
@@ -36,7 +35,6 @@ export default class AsteroidLauncher{
 		const speed = Math.random()*MAX_SPAWN_SPEED;									// random speed		
 		const angle = this.getAngle();
 		const velocity = Vector2.right.rotate(angle).scale(speed); 	// random direction
-		console.log(angle);
 		let asteroid = new Asteroid(velocity, Math.random()-0.5, this.pos, this.game);
 		this.game.spawnDeletableObject(asteroid);
 	}
@@ -44,7 +42,6 @@ export default class AsteroidLauncher{
 	update() {
 		if (this.spawnCount === 0) return;
 		if (this.currentDelay === this.spawnPeriod) {
-			console.log("Spawned new asteroid");
 			this.launchAsteroid();
 			this.currentDelay = 0;
 		} else {

--- a/src/spaceObjects/warpGate.js
+++ b/src/spaceObjects/warpGate.js
@@ -6,6 +6,7 @@ export default class WarpGate extends RenderedObject {
 	constructor(destinationSolarystem, ...args) {
 		super(...args);
 		this.image = this.game.images["warpgate"];
+		this.ctx = "planets";
 		this.height = 50;
 		this.width = 50;
 		this.destinationSolarSystem = destinationSolarystem;


### PR DESCRIPTION
PR contains changes to hardcode solar system data (asteroids/asteroid launchers/planets/warp gates) into the constructor for a solar system object with appropriate scaling according to game screens size (72 units x 54 units). PR also contains changes to warp gates to properly render objects and asteroid launchers to allow for fixed angles & finite period & spawn counts.

All solar systems from the previous iteration have been implemented in the solar system class (with identical galaxies already ported). Most objects have been roughly scaled to be similar to the previous iteration, with the `Kepler 438 System` and `Quaid System` having modulo offsets for asteroids (as these previously had +30 asteroids).

Asteroid launchers were modified to take in additional arguments for `spawnPeriod` (time in seconds between asteroid creations), `spawnCount` (# of asteroids to create -- -1 for infinite), and `rotation` (fixed angle for asteroids -- -1 for randomized angle every creation).


### Todo:
* Only one solar system has planets (need to add more planets throughout galaxy
* Asteroid Launchers generally spawn at edges of map... Random rotation causes majority of asteroids to immediately travel off screen (pass in range of rotations to randomly choose between?)
* Asteroid Launchers have no visual img (asteroids randomly appear)
* Velocity of asteroids created from asteroid launchers likely need to be tweaked (max speed should be lowered)
* No angular speed or velocity are set for asteroids currently (outside of asteroids created from asteroid launchers)
* Implement warp gate travel