### PR TITLE
Fix sensors api heading angle & scan signatures

### DIFF
--- a/src/ship/EMSReading.js
+++ b/src/ship/EMSReading.js
@@ -4,7 +4,7 @@ export default class EMSReading{
 		this.Amplitude = ampltitude; // The strength of the reading, proportional to distance via activeSensors.GConstant //number
 		this.Velocity = velocity; // The velocity of the detected object relative to current solar system coordinate frame //Vector
 		this.Radius = radius; // The collision radius of the detected object //number
-		this.ScanSignature = scanSignature;// A more detail description of the object's material composition //string
+		this.ScanSignature = scanSignature;// A more detail description of the object's material composition //object
 		this.SpecialInfo = specialInfo;// For example, a Warp Gate's destination solar system name //string
 	}
 }

--- a/src/ship/activeSensors.js
+++ b/src/ship/activeSensors.js
@@ -1,5 +1,6 @@
 import EMSReading from "./EMSReading.js";
 import response from "../helpers/response.js";
+import Vector2 from "../helpers/Vector2.js";
 
 export default class ActiveSensors{
     constructor(parentShip){
@@ -9,32 +10,34 @@ export default class ActiveSensors{
 	performScan(heading, arc, range){
         // Ensure solar system is initialized before performing scan
         if (!this.parentShip.solarSystem) return new response(400, ["Cannot perform ActiveSensors performScan until solar system initalized"], []);
-        //User called function for getting sensor data
+
+        // Note: angle must account for relative position of object to ship (not global position on board)
+        // To find angle, find angle difference between the vector from ship to object & current ship heading
+        // y coord is inverted due to the flipped board axis (greater y value indicates lower position)
         let readings = [];
         for (const planet of this.parentShip.solarSystem.planets){
-
-            let dist = planet.pos.distance(this.parentShip.pos);
-            let angle = planet.pos.angleTo(this.parentShip.pos);
-            if (dist+planet.size.x<=range && angle>= -heading && angle<= -heading+arc){
-                let newReading = new EMSReading(angle, dist, 0, planet.size.x, planet.composition, null); //?
+            let dist = this.parentShip.pos.distance(planet.pos);
+            let angle = this.parentShip.angle.angleTo(new Vector2(planet.pos.x - this.parentShip.pos.x, this.parentShip.pos.y - planet.pos.y));
+            if (dist+planet.size.x<=range && angle>= heading && angle<= heading+arc){
+                let newReading = new EMSReading(angle, dist, 0, planet.size.x, planet.composition, null);
                 readings.push(newReading);
             }
         }
 
         for (const warpgate of this.parentShip.solarSystem.warpGates){
-            let dist = warpgate.pos.distance(this.parentShip.pos);
-            let angle = warpgate.pos.angleTo(this.parentShip.pos);
-            if (dist+warpgate.size.x<=range && angle>= -heading && angle<= -heading+arc){
-                let newReading = new EMSReading(angle, dist, 0, warpgate.width, null, warpgate.destinationSolarSystem); //?
+            let dist = this.parentShip.pos.distance(warpgate.pos);
+            let angle = this.parentShip.angle.angleTo(new Vector2(warpgate.pos.x - this.parentShip.pos.x, this.parentShip.pos.y - warpgate.pos.y));
+            if (dist+warpgate.size.x<=range && angle>= heading && angle<= heading+arc){
+                let newReading = new EMSReading(angle, dist, 0, warpgate.width, {}, warpgate.destinationSolarSystem);
                 readings.push(newReading);
             }
         }
 
         for (const asteroid of this.parentShip.solarSystem.asteroids){
-            let dist = asteroid.pos.distance(this.parentShip.pos);
-            let angle = asteroid.pos.angleTo(this.parentShip.pos);
-            if (dist+asteroid.size.x<=range && angle>= -heading && angle<= -heading+arc){
-                let newReading = new EMSReading(angle, dist, asteroid.speed, asteroid.radius, null, null); //?
+            let dist = this.parentShip.pos.distance(asteroid.pos);
+            let angle = this.parentShip.angle.angleTo(new Vector2(asteroid.pos.x - this.parentShip.pos.x, this.parentShip.pos.y - asteroid.pos.y));
+            if (dist+asteroid.size.x<=range && angle>= heading && angle<= heading+arc){
+                let newReading = new EMSReading(angle, dist, asteroid.speed, asteroid.radius, {}, null);
                 readings.push(newReading);
             }
         }

--- a/src/ship/activeSensors.js
+++ b/src/ship/activeSensors.js
@@ -18,7 +18,7 @@ export default class ActiveSensors{
         for (const planet of this.parentShip.solarSystem.planets){
             let dist = this.parentShip.pos.distance(planet.pos);
             let angle = this.parentShip.angle.angleTo(new Vector2(planet.pos.x - this.parentShip.pos.x, this.parentShip.pos.y - planet.pos.y));
-            if (dist+planet.size.x<=range && angle>= heading && angle<= heading+arc){
+            if (dist+planet.size.x<=range && angle <= arc){
                 let newReading = new EMSReading(angle, dist, 0, planet.size.x, planet.composition, null);
                 readings.push(newReading);
             }
@@ -27,7 +27,7 @@ export default class ActiveSensors{
         for (const warpgate of this.parentShip.solarSystem.warpGates){
             let dist = this.parentShip.pos.distance(warpgate.pos);
             let angle = this.parentShip.angle.angleTo(new Vector2(warpgate.pos.x - this.parentShip.pos.x, this.parentShip.pos.y - warpgate.pos.y));
-            if (dist+warpgate.size.x<=range && angle>= heading && angle<= heading+arc){
+            if (dist+warpgate.size.x<=range && angle <= arc){
                 let newReading = new EMSReading(angle, dist, 0, warpgate.width, {}, warpgate.destinationSolarSystem);
                 readings.push(newReading);
             }
@@ -36,7 +36,7 @@ export default class ActiveSensors{
         for (const asteroid of this.parentShip.solarSystem.asteroids){
             let dist = this.parentShip.pos.distance(asteroid.pos);
             let angle = this.parentShip.angle.angleTo(new Vector2(asteroid.pos.x - this.parentShip.pos.x, this.parentShip.pos.y - asteroid.pos.y));
-            if (dist+asteroid.size.x<=range && angle>= heading && angle<= heading+arc){
+            if (dist+asteroid.size.x<=range && angle <= arc){
                 let newReading = new EMSReading(angle, dist, asteroid.speed, asteroid.radius, {}, null);
                 readings.push(newReading);
             }

--- a/src/ship/passiveSensors.js
+++ b/src/ship/passiveSensors.js
@@ -1,5 +1,6 @@
 import PassiveSensorReading from "./passiveSensorReading.js";
 import response from "../helpers/response.js";
+import Vector2 from "../helpers/Vector2.js";
 
 export default class PassiveSensors{
     constructor(parentShip){
@@ -8,15 +9,19 @@ export default class PassiveSensors{
 	generatePassiveSensorReadings(){
         // Ensure solar system is initialized before performing scan
         if (!this.parentShip.solarSystem) return new response(400, ["Cannot perform PassiveSensors generatePassiveSensorReadings until solar system initalized"], []);
+
+        // Note: angle must account for relative position of object to ship (not global position on board)
+        // To find angle, find angle difference between the vector from ship to object & current ship heading
+        // y coord is inverted due to the flipped board axis (greater y value indicates lower position)
         let readings = []; 
         for (const planet of this.parentShip.solarSystem.planets){
-            let angle = planet.pos.angleTo(this.parentShip.pos);    
+            let angle = this.parentShip.angle.angleTo(new Vector2(planet.pos.x - this.parentShip.pos.x, this.parentShip.pos.y - planet.pos.y));
             let newReading = new PassiveSensorReading(angle, planet.gravitySignature);
             readings.push(newReading);
         }
 
         for (const warpgate of this.parentShip.solarSystem.warpGates){
-            let angle = warpgate.pos.angleTo(this.parentShip.pos);
+            let angle = this.parentShip.angle.angleTo(new Vector2(warpgate.pos.x - this.parentShip.pos.x, this.parentShip.pos.y - warpgate.pos.y));
             let newReading = new PassiveSensorReading(angle, warpgate.gravitySignature);
             readings.push(newReading);
         }

--- a/src/solarSystem.js
+++ b/src/solarSystem.js
@@ -39,20 +39,20 @@ export default class SolarSystem{
                     new Asteroid(new Vector2(0, 0), 0.12, new Vector2(54, 20), this.game)
                 ]);
 				this.planets.push(...[
-                    new Planet("planet1", {}, 2, new Vector2(50, 10), this.game),
-                    new Planet("planet2", {}, 2, new Vector2(10, 50), this.game),
-                    new Planet("planet3", {}, 2, new Vector2(60, 35), this.game),
-                    new Planet("planet4", {}, 2, new Vector2(24, 19), this.game),
-                    new Planet("planet5", {}, 2, new Vector2(33, 44), this.game),
-                    new Planet("planet6", {}, 2, new Vector2(4, 9), this.game),
-                    new Planet("planet7", {}, 2, new Vector2(11, 6), this.game),
-                    new Planet("planet8", {}, 2, new Vector2(14, 23), this.game),
-                    new Planet("planet9", {}, 2, new Vector2(19, 21), this.game),
-                    new Planet("planet10", {}, 2, new Vector2(26, 46), this.game),
-                    new Planet("planet11", {}, 2, new Vector2(37, 27), this.game),
-                    new Planet("planet12", {}, 2, new Vector2(34, 40), this.game),
-                    new Planet("planet13", {}, 2, new Vector2(68, 11), this.game),
-                    new Planet("planet14", {}, 2, new Vector2(63, 48), this.game),
+                    new Planet("planet1", {"Common":70, "Metal":20, "Wood":10, "Water":0}, 2, new Vector2(50, 10), this.game),
+                    new Planet("planet2", {"Common":10, "Metal":0, "Wood":70, "Water":0}, 2, new Vector2(10, 50), this.game),
+                    new Planet("planet3", {"Common":40, "Metal":0, "Wood":40, "Water":0}, 2, new Vector2(60, 35), this.game),
+                    new Planet("planet4", {"Common":70, "Metal":0, "Wood":40, "Water":0}, 2, new Vector2(24, 19), this.game),
+                    new Planet("planet5", {"Common":30, "Metal":20, "Terror":10, "Water":0}, 2, new Vector2(33, 44), this.game),
+                    new Planet("planet6", {"Common":70, "Metal":20, "Water":10}, 2, new Vector2(4, 9), this.game),
+                    new Planet("planet7", {"Common":40, "Metal":20, "Terror":10, "Water":0}, 2, new Vector2(11, 6), this.game),
+                    new Planet("planet8", {"Common":110, "Metal":20, "Terror":10, "Water":0}, 2, new Vector2(14, 23), this.game),
+                    new Planet("planet9", {"Common":0, "Metal":0, "Terror":10, "Water":0}, 2, new Vector2(19, 21), this.game),
+                    new Planet("planet10", {"Common":0, "Metal":20, "Terror":10, "Water":0}, 2, new Vector2(26, 46), this.game),
+                    new Planet("planet11", {"Common":10, "Metal":20, "Terror":10, "Water":0}, 2, new Vector2(37, 27), this.game),
+                    new Planet("planet12", {"Common":30, "Metal":20, "Terror":10, "Water":0}, 2, new Vector2(34, 40), this.game),
+                    new Planet("planet13", {"Common":50, "Metal":20, "Terror":10, "Water":0}, 2, new Vector2(68, 11), this.game),
+                    new Planet("planet14", {"Common":170, "Metal":20, "Terror":10, "Water":0}, 2, new Vector2(63, 48), this.game),
                 ]);
 
 				this.asteroidLaunchers.push(new AsteroidLauncher(new Vector2(50, 50), this.game, 4, 10, Math.PI * 3 / 4));

--- a/src/spaceObjects/asteroid.js
+++ b/src/spaceObjects/asteroid.js
@@ -12,6 +12,7 @@ export default class Asteroid extends Sprite {
 		this.size = new Vector2(3, 3);
 		this.radius = this.size.x/2;		// asteroids are circles
 		this.mass = 5;
+		this.gravitySignature = 0;
 	}
 	update() {
 		//Add special update code here if needed


### PR DESCRIPTION
PR contains changes to the calculations for heading/angle in the Sensors API. At the moment, the current heading of the ship is not taken into account when determining the proper arc radius. This is changed so the current heading of the ship is added to the relative positioning of the objects. Formula for distance was kept the same with the only change being in the order of the function call (all taken with respect to the ship instead of the object).

Changes are also made to the created objects in the test galaxy to ensure that sensors will pick up meaningful information (such as planet signatures/etc.